### PR TITLE
add: script tag to load analytics script

### DIFF
--- a/2.3.0/index.html
+++ b/2.3.0/index.html
@@ -10,6 +10,7 @@
 		<script type="text/javascript" src="./js/bootstrap.min.js"></script>
 		<script type="text/javascript" src="./js/prettify.min.js"></script>
 		<script type="text/javascript" src="./js/site.js"></script>
+		<script type="text/javascript" src="https://logging.apache.org/js/analytics.js"></script>
 		<meta name="Date-Revision-yyyymmdd" content="20121013" />
 		<meta http-equiv="Content-Language" content="en" />
 		


### PR DESCRIPTION
This adds a script tag to load the analytics script from https://logging.apache.org/js/ once this [PR](https://github.com/apache/logging-site/pull/5) gets merged.

This aims to keep all the analytics logic in one place.

This is part of our work at [Neighbourhoodie/](https://neighbourhood.ie/) with STF's [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience) for Log4j.